### PR TITLE
Add optional AOD/doze disable switch for OxygenOS devices

### DIFF
--- a/app/src/main/java/com/ztc1997/fakedcbacklight/Hook.kt
+++ b/app/src/main/java/com/ztc1997/fakedcbacklight/Hook.kt
@@ -1,5 +1,6 @@
 package com.ztc1997.fakedcbacklight
 
+import android.view.Display
 import android.content.Context
 import android.provider.Settings
 import de.robv.android.xposed.*
@@ -37,6 +38,7 @@ class Hook : IXposedHookLoadPackage {
                         try {
                             val localDisplayAdapter = XposedHelpers.getSurroundingThis(param.thisObject)
                             val ctx = XposedHelpers.callMethod(localDisplayAdapter, "getOverlayContext") as Context
+                            val state = param.args[0] as Int
                             val targetBright = param.args[1] as Float
 
                             val enable = getBoolean("pref_enable", true)
@@ -50,16 +52,46 @@ class Hook : IXposedHookLoadPackage {
                                 return
                             }
 
+                            
                             val minScreenBright = getFloat("pref_min_screen_bright", 1f)
-                            if (targetBright >= minScreenBright || 
-                                (targetBright < 0 && getBoolean("pref_disable_on_screenoff", false))) {
-                                Settings.Secure.putInt(ctx.contentResolver, "reduce_bright_colors_level", 0)
+                            
+                            val disableOnScreenoff = getBoolean("pref_disable_on_screenoff", false)
+                            val disableOnAodDoze = getBoolean("pref_disable_on_aod_doze", false)
+                            
+                            val isDozeState =
+                                state == Display.STATE_DOZE ||
+                                state == Display.STATE_DOZE_SUSPEND
+                            
+                            // New logic: optional disable on AOD/doze
+                            if (disableOnAodDoze && isDozeState) {
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_level", 0
+                                )
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_activated", 0
+                                )
+                            }
+                            // Original logic kept intact
+                            else if (
+                                targetBright >= minScreenBright ||
+                                (targetBright < 0 && disableOnScreenoff)
+                            ) {
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_level", 0
+                                )
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_activated", 0
+                                )
                             } else if (targetBright >= 0) {
-                                val dim = (1 - (targetBright / minScreenBright)) * getInt("pref_max_dim_strength", 90)
-                                if (checkWriteSettingsPermission(ctx)) {
-                                    Settings.Secure.putInt(ctx.contentResolver, "reduce_bright_colors_level", dim.toInt())
-                                }
-                                Settings.Secure.putInt(ctx.contentResolver, "reduce_bright_colors_activated", 1)
+                                val dim = (1 - (targetBright / minScreenBright)) * getInt(
+                                    "pref_max_dim_strength", 90
+                                )
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_level", dim.toInt()
+                                )
+                                Settings.Secure.putInt(
+                                    ctx.contentResolver, "reduce_bright_colors_activated", 1
+                                )
                                 param.args[1] = minScreenBright
                             }
                         } catch (e: Throwable) {

--- a/app/src/main/java/com/ztc1997/fakedcbacklight/SettingsActivity.kt
+++ b/app/src/main/java/com/ztc1997/fakedcbacklight/SettingsActivity.kt
@@ -25,6 +25,7 @@ class SettingsActivity : Activity() {
     class SettingsFragment : PreferenceFragment() {
         private val enable by lazy { findPreference("pref_enable") as SwitchPreference }
         private val disableOnScreenoff by lazy { findPreference("pref_disable_on_screenoff") as SwitchPreference }
+		private val disableOnAodDoze by lazy { findPreference("pref_disable_on_aod_doze") as SwitchPreference }
         private val minScreenBright by lazy { findPreference("pref_min_screen_bright") as EditTextPreference }
         private val prefMaxDimStrength by lazy { findPreference("pref_max_dim_strength") as EditTextPreference }
         private val halBright by lazy { findPreference("pref_hal_brightness") as Preference }
@@ -71,6 +72,12 @@ class SettingsActivity : Activity() {
                     true
                 }
             disableOnScreenoff.onPreferenceChangeListener =
+                Preference.OnPreferenceChangeListener { prf, value ->
+                    value as Boolean
+                    sp.edit().putBoolean(prf.key, value).apply()
+                    true
+                }
+            disableOnAodDoze.onPreferenceChangeListener =
                 Preference.OnPreferenceChangeListener { prf, value ->
                     value as Boolean
                     sp.edit().putBoolean(prf.key, value).apply()

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,4 +20,6 @@
     <string name="summary_pref_hal_brightness">无法获取 HAL 亮度，激活模块并重启，然后重试</string>
     <string name="title_pref_reduce_bright">当前压暗强度</string>
     <string name="summary_pref_reduce_bright">无法获取压暗强度，激活模块并重启，然后重试</string>
+	<string name="title_pref_disable_on_aod_doze">AOD/Doze 时禁用</string>
+	<string name="summary_pref_disable_on_aod_doze">当显示状态为 DOZE 或 DOZE_SUSPEND 时禁用伪 DC 调光。适用于部分 OxygenOS/ColorOS 机型，因为这些机型的 AOD 不会被识别为真正息屏。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,6 @@
     <string name="summary_pref_hal_brightness">Cannot obtain HAL Brightness, Activate the module and reboot and try again</string>
     <string name="title_pref_reduce_bright">Current Reduce Bright Strength</string>
     <string name="summary_pref_reduce_bright">Cannot obtain Reduce Bright Strength, Activate the module and reboot and try again</string>
+	<string name="title_pref_disable_on_aod_doze">Disable on AOD/Doze</string>
+	<string name="summary_pref_disable_on_aod_doze">Disable fake DC when display state is DOZE or DOZE_SUSPEND. Useful for some OxygenOS/ColorOS devices where AOD is not treated as true screen-off.</string>
 </resources>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -13,6 +13,12 @@
             android:key="pref_disable_on_screenoff"
             android:title="@string/title_pref_disable_on_screenoff"
             android:summary="@string/summary_pref_disable_on_screenoff"/>
+			
+		<SwitchPreference
+            android:key="pref_disable_on_aod_doze"
+            android:title="@string/title_pref_disable_on_aod_doze"
+            android:summary="@string/summary_pref_disable_on_aod_doze"
+            android:defaultValue="false" />	
 
         <EditTextPreference
             android:defaultValue="100"


### PR DESCRIPTION
针对OxygenOS和ColorOS的AOD息屏添加了一个修复功能。
当显示状态为DOZE或DOZE_SUSPEND时禁用伪DC调光。
在 Oneplus 13T (13s) OxygenOS 15 上测试通过。